### PR TITLE
Fix grub install to ubuntu.img.

### DIFF
--- a/grub.cfg
+++ b/grub.cfg
@@ -2,6 +2,7 @@ set default=0
 set timeout=0
 
 menuentry 'Ubuntu' {
-  linux	/vmlinuz root=/dev/sda1 rw console=tty1 console=ttyS0
+	set root=hd(0,1)
+	linux	/vmlinuz root=/dev/sda1 rw console=tty1 console=ttyS0
 	initrd /initrd.img
 }

--- a/run-qemu-test.sh
+++ b/run-qemu-test.sh
@@ -13,11 +13,12 @@ sudo virt-make-fs --partition --format=qcow2 --size=+500M ubuntu.tar ubuntu.img
 sudo chown $USER ubuntu.img
 rm ubuntu.tar
 
-sudo qemu-nbd -d /dev/nbd0
 sudo modprobe nbd max_part=16
+sudo qemu-nbd -d /dev/nbd0
 sudo qemu-nbd -c /dev/nbd0 ubuntu.img
+sleep 1
 sudo mount /dev/nbd0p1 /mnt
-sudo grub-install --root-directory=/mnt /dev/nbd0
+sudo grub-install --target=i386-pc --root-directory=/mnt /dev/nbd0
 sudo umount /mnt
 sudo qemu-nbd -d /dev/nbd0
 


### PR DESCRIPTION
1) Do modprobe nbd before first attempt to disconnect nbd device.
2) Give a sleep after nbd connect before mount (on my setup immediate mount causes enoent)
3) Set root device in grub.cfg
4) Use i386-pc grub target explicitly to run on uefi systems.